### PR TITLE
Use less specific constraint for highlight.php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^7.1",
         "league/commonmark": "^0.18.0",
-        "scrivo/highlight.php": "v9.13.1.1"
+        "scrivo/highlight.php": "^9.14"
     },
     "require-dev": {
         "larapack/dd": "^1.0",


### PR DESCRIPTION
I'd like to propose a less specific constraint for your highlight.php dependency. This will allow users of this project to update highlight.php to a `9.14+` version of the library so they can easily get updates to language definitions. Since highlight.js is seeing active development again, your users may want to get those updated language definitions.

If your concern is backward compatibility, the project has [an explicit promise](https://github.com/scrivo/highlight.php#backward-compatibility-promise) on how we'll handle it.