### PR TITLE
Add `data-lang` attribute to `<code>` block

### DIFF
--- a/src/CodeBlockHighlighter.php
+++ b/src/CodeBlockHighlighter.php
@@ -30,7 +30,7 @@ class CodeBlockHighlighter
             return vsprintf('<code class="%s hljs %s" data-lang="%s">%s</code>', [
                 'language-'.($language ? $language : $result->language),
                 $result->language,
-                $result->language,
+                $language ? $language : $result->language,
                 $result->value,
             ]);
         } catch (DomainException $e) {

--- a/src/CodeBlockHighlighter.php
+++ b/src/CodeBlockHighlighter.php
@@ -27,8 +27,9 @@ class CodeBlockHighlighter
                 ? $this->highlighter->highlight($language, $contents)
                 : $this->highlighter->highlightAuto($contents);
 
-            return vsprintf('<code class="%s hljs %s">%s</code>', [
+            return vsprintf('<code class="%s hljs %s" data-lang="%s">%s</code>', [
                 'language-'.($language ? $language : $result->language),
+                $result->language,
                 $result->language,
                 $result->value,
             ]);

--- a/tests/__snapshots__/FencedCodeRendererTest__it_highlights_code_blocks_with_a_specified_language__1.xml
+++ b/tests/__snapshots__/FencedCodeRendererTest__it_highlights_code_blocks_with_a_specified_language__1.xml
@@ -2,7 +2,7 @@
 <div>
   <p>Which looks like this in use:</p>
   <pre>
-    <code class="language-html hljs xml" data-lang="xml">
+    <code class="language-html hljs xml" data-lang="html">
       <span class="hljs-tag">&lt;<span class="hljs-name">generic-form</span>
     <span class="hljs-attr">:showBackButton</span>=<span class="hljs-string">"true"</span>
     @<span class="hljs-attr">back</span>=<span class="hljs-string">"goBack"</span>

--- a/tests/__snapshots__/FencedCodeRendererTest__it_highlights_code_blocks_with_a_specified_language__1.xml
+++ b/tests/__snapshots__/FencedCodeRendererTest__it_highlights_code_blocks_with_a_specified_language__1.xml
@@ -2,7 +2,7 @@
 <div>
   <p>Which looks like this in use:</p>
   <pre>
-    <code class="language-html hljs xml">
+    <code class="language-html hljs xml" data-lang="xml">
       <span class="hljs-tag">&lt;<span class="hljs-name">generic-form</span>
     <span class="hljs-attr">:showBackButton</span>=<span class="hljs-string">"true"</span>
     @<span class="hljs-attr">back</span>=<span class="hljs-string">"goBack"</span>

--- a/tests/__snapshots__/FencedCodeRendererTest__it_highlights_code_blocks_with_an_autodetected_language__1.xml
+++ b/tests/__snapshots__/FencedCodeRendererTest__it_highlights_code_blocks_with_an_autodetected_language__1.xml
@@ -2,7 +2,7 @@
 <div>
   <p>Which looks like this in use:</p>
   <pre>
-    <code class="language-xml hljs xml">
+    <code class="language-xml hljs xml" data-lang="xml">
       <span class="hljs-tag">&lt;<span class="hljs-name">generic-form</span>
     <span class="hljs-attr">:showBackButton</span>=<span class="hljs-string">"true"</span>
     @<span class="hljs-attr">back</span>=<span class="hljs-string">"goBack"</span>

--- a/tests/__snapshots__/IndentedCodeRendererTest__it_highlights_code_blocks__1.xml
+++ b/tests/__snapshots__/IndentedCodeRendererTest__it_highlights_code_blocks__1.xml
@@ -2,7 +2,7 @@
 <div>
   <p>Which looks like this in use:</p>
   <pre>
-    <code class="language-xml hljs xml">
+    <code class="language-xml hljs xml" data-lang="xml">
       <span class="hljs-tag">&lt;<span class="hljs-name">generic-form</span>
     <span class="hljs-attr">:showBackButton</span>=<span class="hljs-string">"true"</span>
     @<span class="hljs-attr">back</span>=<span class="hljs-string">"goBack"</span>


### PR DESCRIPTION
This adds an attribute to the generated HTML node that will allow it to be reliably programatically selected if parsing the output.

It also gives an opportunity to show the language on the code block with CSS:

```css
code[data-lang]::before {
  content: attr(data-lang);
  position: absolute;
}
```