### PR TITLE
Add support for highlighting specific lines

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^7.2",
         "league/commonmark": "^1.0",
-        "scrivo/highlight.php": "^9.14"
+        "scrivo/highlight.php": "^9.15.6.1"
     },
     "require-dev": {
         "larapack/dd": "^1.0",

--- a/src/CodeBlockHighlighter.php
+++ b/src/CodeBlockHighlighter.php
@@ -4,6 +4,7 @@ namespace Spatie\CommonMarkHighlighter;
 
 use DomainException;
 use Highlight\Highlighter;
+use function HighlightUtilities\splitCodeIntoArray;
 
 class CodeBlockHighlighter
 {
@@ -17,24 +18,87 @@ class CodeBlockHighlighter
         $this->highlighter->setAutodetectLanguages($autodetectLanguages);
     }
 
-    public function highlight(string $codeBlock, ?string $language = null)
+    public function highlight(string $codeBlock, ?string $infoLine = null)
     {
         $codeBlockWithoutTags = strip_tags($codeBlock);
         $contents = htmlspecialchars_decode($codeBlockWithoutTags);
+
+        $definition = $this->parseLangAndLines($infoLine);
+        $language = $definition['lang'];
 
         try {
             $result = $language
                 ? $this->highlighter->highlight($language, $contents)
                 : $this->highlighter->highlightAuto($contents);
 
+            $code = $result->value;
+
+            if (count($definition['lines']) > 0) {
+                $loc = splitCodeIntoArray($code);
+
+                foreach ($loc as $i => $line) {
+                    $loc[$i] = vsprintf('<span class="loc%s">%s</span>', [
+                        isset($definition['lines'][$i + 1]) ? ' highlighted' : '',
+                        $line,
+                    ]);
+                }
+
+                $code = implode("\n", $loc);
+            }
+
             return vsprintf('<code class="%s hljs %s" data-lang="%s">%s</code>', [
                 'language-'.($language ? $language : $result->language),
                 $result->language,
                 $language ? $language : $result->language,
-                $result->value,
+                $code,
             ]);
         } catch (DomainException $e) {
             return $codeBlock;
         }
+    }
+
+    private function parseLangAndLines(?string $language)
+    {
+        $parsed = [
+            'lang' => $language,
+            'lines' => [],
+        ];
+
+        if ($language === null) {
+            return $parsed;
+        }
+
+        $bracePos = strpos($language, '{');
+
+        if ($bracePos === false) {
+            return $parsed;
+        }
+
+        $parsed['lang'] = substr($language, 0, $bracePos);
+        $lineDef = substr($language, $bracePos + 1, -1);
+        $lineNums = explode(',', $lineDef);
+
+        foreach ($lineNums as $lineNum) {
+            if (strpos($lineNum, '-') === false) {
+                $parsed['lines'][intval($lineNum)] = true;
+
+                continue;
+            }
+
+            $extremes = explode('-', $lineNum);
+
+            if (count($extremes) !== 2) {
+                continue;
+            }
+
+            $start = intval($extremes[0]);
+            $end = intval($extremes[1]);
+
+            for ($i = $start; $i <= $end; $i++) {
+                $parsed['lines'][$i] = true;
+            }
+        }
+
+        return $parsed;
     }
 }

--- a/tests/FencedCodeRendererTest.php
+++ b/tests/FencedCodeRendererTest.php
@@ -44,6 +44,198 @@ MARKDOWN;
     }
 
     /** @test */
+    public function it_highlights_code_blocks_with_a_specified_language_and_single_line()
+    {
+        $markdown = <<<'MARKDOWN'
+Which looks like this in use:
+
+```html{5}
+<generic-form
+    :showBackButton="true"
+    @back="goBack"
+>
+    <input type="text" name="send-to">
+    <input type="number" name="amount" />
+</generic-form>
+```
+
+Something feels wrong here.
+MARKDOWN;
+
+        $environment = Environment::createCommonMarkEnvironment();
+        $environment->addBlockRenderer(FencedCode::class, new FencedCodeRenderer(['html']));
+
+        $parser = new DocParser($environment);
+        $htmlRenderer = new HtmlRenderer($environment);
+
+        $document = $parser->parse($markdown);
+
+        $html = $htmlRenderer->renderBlock($document);
+
+        $this->assertMatchesXmlSnapshot('<div>'.$html.'</div>');
+    }
+
+    /** @test */
+    public function it_highlights_code_blocks_with_a_specified_language_and_line_range()
+    {
+        $markdown = <<<'MARKDOWN'
+Which looks like this in use:
+
+```html{2-3}
+<generic-form
+    :showBackButton="true"
+    @back="goBack"
+>
+    <input type="text" name="send-to">
+    <input type="number" name="amount" />
+</generic-form>
+```
+
+Something feels wrong here.
+MARKDOWN;
+
+        $environment = Environment::createCommonMarkEnvironment();
+        $environment->addBlockRenderer(FencedCode::class, new FencedCodeRenderer(['html']));
+
+        $parser = new DocParser($environment);
+        $htmlRenderer = new HtmlRenderer($environment);
+
+        $document = $parser->parse($markdown);
+
+        $html = $htmlRenderer->renderBlock($document);
+
+        $this->assertMatchesXmlSnapshot('<div>'.$html.'</div>');
+    }
+
+    /** @test */
+    public function it_highlights_code_blocks_with_a_specified_language_and_multiple_line_range()
+    {
+        $markdown = <<<'MARKDOWN'
+Which looks like this in use:
+
+```html{2-3,5-6}
+<generic-form
+    :showBackButton="true"
+    @back="goBack"
+>
+    <input type="text" name="send-to">
+    <input type="number" name="amount" />
+</generic-form>
+```
+
+Something feels wrong here.
+MARKDOWN;
+
+        $environment = Environment::createCommonMarkEnvironment();
+        $environment->addBlockRenderer(FencedCode::class, new FencedCodeRenderer(['html']));
+
+        $parser = new DocParser($environment);
+        $htmlRenderer = new HtmlRenderer($environment);
+
+        $document = $parser->parse($markdown);
+
+        $html = $htmlRenderer->renderBlock($document);
+
+        $this->assertMatchesXmlSnapshot('<div>'.$html.'</div>');
+    }
+
+    /** @test */
+    public function it_highlights_code_blocks_with_a_specified_language_and_multiple_separate_lines()
+    {
+        $markdown = <<<'MARKDOWN'
+Which looks like this in use:
+
+```html{1,7}
+<generic-form
+    :showBackButton="true"
+    @back="goBack"
+>
+    <input type="text" name="send-to">
+    <input type="number" name="amount" />
+</generic-form>
+```
+
+Something feels wrong here.
+MARKDOWN;
+
+        $environment = Environment::createCommonMarkEnvironment();
+        $environment->addBlockRenderer(FencedCode::class, new FencedCodeRenderer(['html']));
+
+        $parser = new DocParser($environment);
+        $htmlRenderer = new HtmlRenderer($environment);
+
+        $document = $parser->parse($markdown);
+
+        $html = $htmlRenderer->renderBlock($document);
+
+        $this->assertMatchesXmlSnapshot('<div>'.$html.'</div>');
+    }
+
+    /** @test */
+    public function it_highlights_code_blocks_with_a_specified_language_and_mix_ranges_specific_lines()
+    {
+        $markdown = <<<'MARKDOWN'
+Which looks like this in use:
+
+```html{1,2-3,5,7}
+<generic-form
+    :showBackButton="true"
+    @back="goBack"
+>
+    <input type="text" name="send-to">
+    <input type="number" name="amount" />
+</generic-form>
+```
+
+Something feels wrong here.
+MARKDOWN;
+
+        $environment = Environment::createCommonMarkEnvironment();
+        $environment->addBlockRenderer(FencedCode::class, new FencedCodeRenderer(['html']));
+
+        $parser = new DocParser($environment);
+        $htmlRenderer = new HtmlRenderer($environment);
+
+        $document = $parser->parse($markdown);
+
+        $html = $htmlRenderer->renderBlock($document);
+
+        $this->assertMatchesXmlSnapshot('<div>'.$html.'</div>');
+    }
+
+    /** @test */
+    public function it_highlights_code_blocks_with_a_specified_language_and_lines_out_of_order()
+    {
+        $markdown = <<<'MARKDOWN'
+Which looks like this in use:
+
+```html{7,1,3,2}
+<generic-form
+    :showBackButton="true"
+    @back="goBack"
+>
+    <input type="text" name="send-to">
+    <input type="number" name="amount" />
+</generic-form>
+```
+
+Something feels wrong here.
+MARKDOWN;
+
+        $environment = Environment::createCommonMarkEnvironment();
+        $environment->addBlockRenderer(FencedCode::class, new FencedCodeRenderer(['html']));
+
+        $parser = new DocParser($environment);
+        $htmlRenderer = new HtmlRenderer($environment);
+
+        $document = $parser->parse($markdown);
+
+        $html = $htmlRenderer->renderBlock($document);
+
+        $this->assertMatchesXmlSnapshot('<div>'.$html.'</div>');
+    }
+
+    /** @test */
     public function it_highlights_code_blocks_with_an_autodetected_language()
     {
         $markdown = <<<'MARKDOWN'

--- a/tests/__snapshots__/FencedCodeRendererTest__it_highlights_code_blocks_with_a_specified_language_and_line_range__1.xml
+++ b/tests/__snapshots__/FencedCodeRendererTest__it_highlights_code_blocks_with_a_specified_language_and_line_range__1.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<div>
+  <p>Which looks like this in use:</p>
+  <pre>
+    <code class="language-html hljs xml" data-lang="html">
+      <span class="loc">
+        <span class="hljs-tag">&lt;<span class="hljs-name">generic-form</span></span>
+      </span>
+      <span class="loc highlighted">
+        <span class="hljs-tag"><span class="hljs-attr">:showBackButton</span>=<span class="hljs-string">"true"</span></span>
+      </span>
+      <span class="loc highlighted">
+        <span class="hljs-tag">    @<span class="hljs-attr">back</span>=<span class="hljs-string">"goBack"</span></span>
+      </span>
+      <span class="loc">
+        <span class="hljs-tag">&gt;</span>
+      </span>
+      <span class="loc">
+        <span class="hljs-tag">&lt;<span class="hljs-name">input</span> <span class="hljs-attr">type</span>=<span class="hljs-string">"text"</span> <span class="hljs-attr">name</span>=<span class="hljs-string">"send-to"</span>&gt;</span>
+      </span>
+      <span class="loc">
+        <span class="hljs-tag">&lt;<span class="hljs-name">input</span> <span class="hljs-attr">type</span>=<span class="hljs-string">"number"</span> <span class="hljs-attr">name</span>=<span class="hljs-string">"amount"</span> /&gt;</span>
+      </span>
+      <span class="loc">
+        <span class="hljs-tag">&lt;/<span class="hljs-name">generic-form</span>&gt;</span>
+      </span>
+      <span class="loc"/>
+    </code>
+  </pre>
+  <p>Something feels wrong here.</p>
+</div>

--- a/tests/__snapshots__/FencedCodeRendererTest__it_highlights_code_blocks_with_a_specified_language_and_lines_out_of_order__1.xml
+++ b/tests/__snapshots__/FencedCodeRendererTest__it_highlights_code_blocks_with_a_specified_language_and_lines_out_of_order__1.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<div>
+  <p>Which looks like this in use:</p>
+  <pre>
+    <code class="language-html hljs xml" data-lang="html">
+      <span class="loc highlighted">
+        <span class="hljs-tag">&lt;<span class="hljs-name">generic-form</span></span>
+      </span>
+      <span class="loc highlighted">
+        <span class="hljs-tag"><span class="hljs-attr">:showBackButton</span>=<span class="hljs-string">"true"</span></span>
+      </span>
+      <span class="loc highlighted">
+        <span class="hljs-tag">    @<span class="hljs-attr">back</span>=<span class="hljs-string">"goBack"</span></span>
+      </span>
+      <span class="loc">
+        <span class="hljs-tag">&gt;</span>
+      </span>
+      <span class="loc">
+        <span class="hljs-tag">&lt;<span class="hljs-name">input</span> <span class="hljs-attr">type</span>=<span class="hljs-string">"text"</span> <span class="hljs-attr">name</span>=<span class="hljs-string">"send-to"</span>&gt;</span>
+      </span>
+      <span class="loc">
+        <span class="hljs-tag">&lt;<span class="hljs-name">input</span> <span class="hljs-attr">type</span>=<span class="hljs-string">"number"</span> <span class="hljs-attr">name</span>=<span class="hljs-string">"amount"</span> /&gt;</span>
+      </span>
+      <span class="loc highlighted">
+        <span class="hljs-tag">&lt;/<span class="hljs-name">generic-form</span>&gt;</span>
+      </span>
+      <span class="loc"/>
+    </code>
+  </pre>
+  <p>Something feels wrong here.</p>
+</div>

--- a/tests/__snapshots__/FencedCodeRendererTest__it_highlights_code_blocks_with_a_specified_language_and_mix_ranges_specific_lines__1.xml
+++ b/tests/__snapshots__/FencedCodeRendererTest__it_highlights_code_blocks_with_a_specified_language_and_mix_ranges_specific_lines__1.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<div>
+  <p>Which looks like this in use:</p>
+  <pre>
+    <code class="language-html hljs xml" data-lang="html">
+      <span class="loc highlighted">
+        <span class="hljs-tag">&lt;<span class="hljs-name">generic-form</span></span>
+      </span>
+      <span class="loc highlighted">
+        <span class="hljs-tag"><span class="hljs-attr">:showBackButton</span>=<span class="hljs-string">"true"</span></span>
+      </span>
+      <span class="loc highlighted">
+        <span class="hljs-tag">    @<span class="hljs-attr">back</span>=<span class="hljs-string">"goBack"</span></span>
+      </span>
+      <span class="loc">
+        <span class="hljs-tag">&gt;</span>
+      </span>
+      <span class="loc highlighted">
+        <span class="hljs-tag">&lt;<span class="hljs-name">input</span> <span class="hljs-attr">type</span>=<span class="hljs-string">"text"</span> <span class="hljs-attr">name</span>=<span class="hljs-string">"send-to"</span>&gt;</span>
+      </span>
+      <span class="loc">
+        <span class="hljs-tag">&lt;<span class="hljs-name">input</span> <span class="hljs-attr">type</span>=<span class="hljs-string">"number"</span> <span class="hljs-attr">name</span>=<span class="hljs-string">"amount"</span> /&gt;</span>
+      </span>
+      <span class="loc highlighted">
+        <span class="hljs-tag">&lt;/<span class="hljs-name">generic-form</span>&gt;</span>
+      </span>
+      <span class="loc"/>
+    </code>
+  </pre>
+  <p>Something feels wrong here.</p>
+</div>

--- a/tests/__snapshots__/FencedCodeRendererTest__it_highlights_code_blocks_with_a_specified_language_and_multiple_line_range__1.xml
+++ b/tests/__snapshots__/FencedCodeRendererTest__it_highlights_code_blocks_with_a_specified_language_and_multiple_line_range__1.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<div>
+  <p>Which looks like this in use:</p>
+  <pre>
+    <code class="language-html hljs xml" data-lang="html">
+      <span class="loc">
+        <span class="hljs-tag">&lt;<span class="hljs-name">generic-form</span></span>
+      </span>
+      <span class="loc highlighted">
+        <span class="hljs-tag"><span class="hljs-attr">:showBackButton</span>=<span class="hljs-string">"true"</span></span>
+      </span>
+      <span class="loc highlighted">
+        <span class="hljs-tag">    @<span class="hljs-attr">back</span>=<span class="hljs-string">"goBack"</span></span>
+      </span>
+      <span class="loc">
+        <span class="hljs-tag">&gt;</span>
+      </span>
+      <span class="loc highlighted">
+        <span class="hljs-tag">&lt;<span class="hljs-name">input</span> <span class="hljs-attr">type</span>=<span class="hljs-string">"text"</span> <span class="hljs-attr">name</span>=<span class="hljs-string">"send-to"</span>&gt;</span>
+      </span>
+      <span class="loc highlighted">
+        <span class="hljs-tag">&lt;<span class="hljs-name">input</span> <span class="hljs-attr">type</span>=<span class="hljs-string">"number"</span> <span class="hljs-attr">name</span>=<span class="hljs-string">"amount"</span> /&gt;</span>
+      </span>
+      <span class="loc">
+        <span class="hljs-tag">&lt;/<span class="hljs-name">generic-form</span>&gt;</span>
+      </span>
+      <span class="loc"/>
+    </code>
+  </pre>
+  <p>Something feels wrong here.</p>
+</div>

--- a/tests/__snapshots__/FencedCodeRendererTest__it_highlights_code_blocks_with_a_specified_language_and_multiple_separate_lines__1.xml
+++ b/tests/__snapshots__/FencedCodeRendererTest__it_highlights_code_blocks_with_a_specified_language_and_multiple_separate_lines__1.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<div>
+  <p>Which looks like this in use:</p>
+  <pre>
+    <code class="language-html hljs xml" data-lang="html">
+      <span class="loc highlighted">
+        <span class="hljs-tag">&lt;<span class="hljs-name">generic-form</span></span>
+      </span>
+      <span class="loc">
+        <span class="hljs-tag"><span class="hljs-attr">:showBackButton</span>=<span class="hljs-string">"true"</span></span>
+      </span>
+      <span class="loc">
+        <span class="hljs-tag">    @<span class="hljs-attr">back</span>=<span class="hljs-string">"goBack"</span></span>
+      </span>
+      <span class="loc">
+        <span class="hljs-tag">&gt;</span>
+      </span>
+      <span class="loc">
+        <span class="hljs-tag">&lt;<span class="hljs-name">input</span> <span class="hljs-attr">type</span>=<span class="hljs-string">"text"</span> <span class="hljs-attr">name</span>=<span class="hljs-string">"send-to"</span>&gt;</span>
+      </span>
+      <span class="loc">
+        <span class="hljs-tag">&lt;<span class="hljs-name">input</span> <span class="hljs-attr">type</span>=<span class="hljs-string">"number"</span> <span class="hljs-attr">name</span>=<span class="hljs-string">"amount"</span> /&gt;</span>
+      </span>
+      <span class="loc highlighted">
+        <span class="hljs-tag">&lt;/<span class="hljs-name">generic-form</span>&gt;</span>
+      </span>
+      <span class="loc"/>
+    </code>
+  </pre>
+  <p>Something feels wrong here.</p>
+</div>

--- a/tests/__snapshots__/FencedCodeRendererTest__it_highlights_code_blocks_with_a_specified_language_and_single_line__1.xml
+++ b/tests/__snapshots__/FencedCodeRendererTest__it_highlights_code_blocks_with_a_specified_language_and_single_line__1.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<div>
+  <p>Which looks like this in use:</p>
+  <pre>
+    <code class="language-html hljs xml" data-lang="html">
+      <span class="loc">
+        <span class="hljs-tag">&lt;<span class="hljs-name">generic-form</span></span>
+      </span>
+      <span class="loc">
+        <span class="hljs-tag"><span class="hljs-attr">:showBackButton</span>=<span class="hljs-string">"true"</span></span>
+      </span>
+      <span class="loc">
+        <span class="hljs-tag">    @<span class="hljs-attr">back</span>=<span class="hljs-string">"goBack"</span></span>
+      </span>
+      <span class="loc">
+        <span class="hljs-tag">&gt;</span>
+      </span>
+      <span class="loc highlighted">
+        <span class="hljs-tag">&lt;<span class="hljs-name">input</span> <span class="hljs-attr">type</span>=<span class="hljs-string">"text"</span> <span class="hljs-attr">name</span>=<span class="hljs-string">"send-to"</span>&gt;</span>
+      </span>
+      <span class="loc">
+        <span class="hljs-tag">&lt;<span class="hljs-name">input</span> <span class="hljs-attr">type</span>=<span class="hljs-string">"number"</span> <span class="hljs-attr">name</span>=<span class="hljs-string">"amount"</span> /&gt;</span>
+      </span>
+      <span class="loc">
+        <span class="hljs-tag">&lt;/<span class="hljs-name">generic-form</span>&gt;</span>
+      </span>
+      <span class="loc"/>
+    </code>
+  </pre>
+  <p>Something feels wrong here.</p>
+</div>


### PR DESCRIPTION
Line numbers start at 1. The current supported syntax is the following:

- `lang` - Don't highlight any lines
- `lang{4}` - Highlight just line 4
- `lang{4-6}` - Highlight the range of lines from 4 to 6 (inclusive)
- `lang{1,5}` - Highlight just lines 1 and 5 on their own
- `lang{1-3,5}` - Highlight 1 through 3 and then 5 on its own
- `lang{5,7,2-3}` - The order of lines don't matter
  -  However, specifying `3-2` will not work.

I use `strpos` and `substr` instead of a regular expression for performance. However, I'm open to changing it if a regex is preferred.

My questions for the maintainers:

- This feature surrounds each line with `<span class="loc"></span>` and a `highlighted` class is added to this span to highlight lines. Not sure if you'd prefer to handle this differently?
- Is there a better way of handling unit tests without so much repeated setup in each test?
- The `HighlightUtilities\splitCodeIntoArray()` function was introduced in [v9.15.6.1](https://github.com/scrivo/highlight.php/releases/tag/v9.15.6.1) of highlight.php. I'm not sure how you'd want to handle the unit tests with `--prefer-lowest`

Closes #9