### PR TITLE
Fix UTF-8 support in highlight blocks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^7.2",
         "league/commonmark": "^1.0",
-        "scrivo/highlight.php": "^9.15.6.1"
+        "scrivo/highlight.php": "^9.18.1.2"
     },
     "require-dev": {
         "larapack/dd": "^1.0",

--- a/tests/FencedCodeRendererTest.php
+++ b/tests/FencedCodeRendererTest.php
@@ -236,6 +236,33 @@ MARKDOWN;
     }
 
     /** @test */
+    public function it_highlights_code_blocks_with_a_specified_language_and_line_range_with_emojis()
+    {
+        $markdown = <<<'MARKDOWN'
+Which looks like this in use:
+
+```php{2}
+// ✅ ...
+$isUserPending = $user->isStatus("pending");
+```
+
+Something feels wrong here.
+MARKDOWN;
+
+        $environment = Environment::createCommonMarkEnvironment();
+        $environment->addBlockRenderer(FencedCode::class, new FencedCodeRenderer(['html']));
+
+        $parser = new DocParser($environment);
+        $htmlRenderer = new HtmlRenderer($environment);
+
+        $document = $parser->parse($markdown);
+
+        $html = $htmlRenderer->renderBlock($document);
+
+        $this->assertMatchesXmlSnapshot('<div>'.$html.'</div>');
+    }
+
+    /** @test */
     public function it_highlights_code_blocks_with_an_autodetected_language()
     {
         $markdown = <<<'MARKDOWN'

--- a/tests/__snapshots__/FencedCodeRendererTest__it_highlights_code_blocks_with_a_specified_language_and_line_range_with_emojis__1.xml
+++ b/tests/__snapshots__/FencedCodeRendererTest__it_highlights_code_blocks_with_a_specified_language_and_line_range_with_emojis__1.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<div>
+  <p>Which looks like this in use:</p>
+  <pre>
+    <code class="language-php hljs php" data-lang="php">
+      <span class="loc">
+        <span class="hljs-comment">// ✅ ...</span>
+      </span>
+      <span class="loc highlighted">$isUserPending = $user-&gt;isStatus(<span class="hljs-string">"pending"</span>);</span>
+      <span class="loc"/>
+    </code>
+  </pre>
+  <p>Something feels wrong here.</p>
+</div>


### PR DESCRIPTION
Because emojis are cool :sunglasses: We should probably require a version of highlight.php that handles it correctly.

Fixes #13﻿
