### PR TITLE
chore: update to latest highlight.php version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^7.2",
         "league/commonmark": "^1.0",
-        "scrivo/highlight.php": "^9.18.1.2"
+        "scrivo/highlight.php": "^9.18.1.4"
     },
     "require-dev": {
         "larapack/dd": "^1.0",

--- a/tests/__snapshots__/FencedCodeRendererTest__it_highlights_code_blocks_with_a_specified_language_and_line_range__1.xml
+++ b/tests/__snapshots__/FencedCodeRendererTest__it_highlights_code_blocks_with_a_specified_language_and_line_range__1.xml
@@ -5,15 +5,9 @@
     <code class="language-html hljs xml" data-lang="html">
       <span class="loc">
         <span class="hljs-tag">&lt;<span class="hljs-name">generic-form</span></span>
-      </span>
-      <span class="loc highlighted">
-        <span class="hljs-tag"><span class="hljs-attr">:showBackButton</span>=<span class="hljs-string">"true"</span></span>
-      </span>
-      <span class="loc highlighted">
-        <span class="hljs-tag">    @<span class="hljs-attr">back</span>=<span class="hljs-string">"goBack"</span></span>
-      </span>
-      <span class="loc">
-        <span class="hljs-tag">&gt;</span>
+        <span class="loc highlighted"><span class="hljs-attr">:showBackButton</span>=<span class="hljs-string">"true"</span></span>
+        <span class="loc highlighted">    @<span class="hljs-attr">back</span>=<span class="hljs-string">"goBack"</span></span>
+        <span class="loc">&gt;</span>
       </span>
       <span class="loc">
         <span class="hljs-tag">&lt;<span class="hljs-name">input</span> <span class="hljs-attr">type</span>=<span class="hljs-string">"text"</span> <span class="hljs-attr">name</span>=<span class="hljs-string">"send-to"</span>&gt;</span>

--- a/tests/__snapshots__/FencedCodeRendererTest__it_highlights_code_blocks_with_a_specified_language_and_lines_out_of_order__1.xml
+++ b/tests/__snapshots__/FencedCodeRendererTest__it_highlights_code_blocks_with_a_specified_language_and_lines_out_of_order__1.xml
@@ -5,15 +5,9 @@
     <code class="language-html hljs xml" data-lang="html">
       <span class="loc highlighted">
         <span class="hljs-tag">&lt;<span class="hljs-name">generic-form</span></span>
-      </span>
-      <span class="loc highlighted">
-        <span class="hljs-tag"><span class="hljs-attr">:showBackButton</span>=<span class="hljs-string">"true"</span></span>
-      </span>
-      <span class="loc highlighted">
-        <span class="hljs-tag">    @<span class="hljs-attr">back</span>=<span class="hljs-string">"goBack"</span></span>
-      </span>
-      <span class="loc">
-        <span class="hljs-tag">&gt;</span>
+        <span class="loc highlighted"><span class="hljs-attr">:showBackButton</span>=<span class="hljs-string">"true"</span></span>
+        <span class="loc highlighted">    @<span class="hljs-attr">back</span>=<span class="hljs-string">"goBack"</span></span>
+        <span class="loc">&gt;</span>
       </span>
       <span class="loc">
         <span class="hljs-tag">&lt;<span class="hljs-name">input</span> <span class="hljs-attr">type</span>=<span class="hljs-string">"text"</span> <span class="hljs-attr">name</span>=<span class="hljs-string">"send-to"</span>&gt;</span>

--- a/tests/__snapshots__/FencedCodeRendererTest__it_highlights_code_blocks_with_a_specified_language_and_mix_ranges_specific_lines__1.xml
+++ b/tests/__snapshots__/FencedCodeRendererTest__it_highlights_code_blocks_with_a_specified_language_and_mix_ranges_specific_lines__1.xml
@@ -5,15 +5,9 @@
     <code class="language-html hljs xml" data-lang="html">
       <span class="loc highlighted">
         <span class="hljs-tag">&lt;<span class="hljs-name">generic-form</span></span>
-      </span>
-      <span class="loc highlighted">
-        <span class="hljs-tag"><span class="hljs-attr">:showBackButton</span>=<span class="hljs-string">"true"</span></span>
-      </span>
-      <span class="loc highlighted">
-        <span class="hljs-tag">    @<span class="hljs-attr">back</span>=<span class="hljs-string">"goBack"</span></span>
-      </span>
-      <span class="loc">
-        <span class="hljs-tag">&gt;</span>
+        <span class="loc highlighted"><span class="hljs-attr">:showBackButton</span>=<span class="hljs-string">"true"</span></span>
+        <span class="loc highlighted">    @<span class="hljs-attr">back</span>=<span class="hljs-string">"goBack"</span></span>
+        <span class="loc">&gt;</span>
       </span>
       <span class="loc highlighted">
         <span class="hljs-tag">&lt;<span class="hljs-name">input</span> <span class="hljs-attr">type</span>=<span class="hljs-string">"text"</span> <span class="hljs-attr">name</span>=<span class="hljs-string">"send-to"</span>&gt;</span>

--- a/tests/__snapshots__/FencedCodeRendererTest__it_highlights_code_blocks_with_a_specified_language_and_multiple_line_range__1.xml
+++ b/tests/__snapshots__/FencedCodeRendererTest__it_highlights_code_blocks_with_a_specified_language_and_multiple_line_range__1.xml
@@ -5,15 +5,9 @@
     <code class="language-html hljs xml" data-lang="html">
       <span class="loc">
         <span class="hljs-tag">&lt;<span class="hljs-name">generic-form</span></span>
-      </span>
-      <span class="loc highlighted">
-        <span class="hljs-tag"><span class="hljs-attr">:showBackButton</span>=<span class="hljs-string">"true"</span></span>
-      </span>
-      <span class="loc highlighted">
-        <span class="hljs-tag">    @<span class="hljs-attr">back</span>=<span class="hljs-string">"goBack"</span></span>
-      </span>
-      <span class="loc">
-        <span class="hljs-tag">&gt;</span>
+        <span class="loc highlighted"><span class="hljs-attr">:showBackButton</span>=<span class="hljs-string">"true"</span></span>
+        <span class="loc highlighted">    @<span class="hljs-attr">back</span>=<span class="hljs-string">"goBack"</span></span>
+        <span class="loc">&gt;</span>
       </span>
       <span class="loc highlighted">
         <span class="hljs-tag">&lt;<span class="hljs-name">input</span> <span class="hljs-attr">type</span>=<span class="hljs-string">"text"</span> <span class="hljs-attr">name</span>=<span class="hljs-string">"send-to"</span>&gt;</span>

--- a/tests/__snapshots__/FencedCodeRendererTest__it_highlights_code_blocks_with_a_specified_language_and_multiple_separate_lines__1.xml
+++ b/tests/__snapshots__/FencedCodeRendererTest__it_highlights_code_blocks_with_a_specified_language_and_multiple_separate_lines__1.xml
@@ -5,15 +5,9 @@
     <code class="language-html hljs xml" data-lang="html">
       <span class="loc highlighted">
         <span class="hljs-tag">&lt;<span class="hljs-name">generic-form</span></span>
-      </span>
-      <span class="loc">
-        <span class="hljs-tag"><span class="hljs-attr">:showBackButton</span>=<span class="hljs-string">"true"</span></span>
-      </span>
-      <span class="loc">
-        <span class="hljs-tag">    @<span class="hljs-attr">back</span>=<span class="hljs-string">"goBack"</span></span>
-      </span>
-      <span class="loc">
-        <span class="hljs-tag">&gt;</span>
+        <span class="loc"><span class="hljs-attr">:showBackButton</span>=<span class="hljs-string">"true"</span></span>
+        <span class="loc">    @<span class="hljs-attr">back</span>=<span class="hljs-string">"goBack"</span></span>
+        <span class="loc">&gt;</span>
       </span>
       <span class="loc">
         <span class="hljs-tag">&lt;<span class="hljs-name">input</span> <span class="hljs-attr">type</span>=<span class="hljs-string">"text"</span> <span class="hljs-attr">name</span>=<span class="hljs-string">"send-to"</span>&gt;</span>

--- a/tests/__snapshots__/FencedCodeRendererTest__it_highlights_code_blocks_with_a_specified_language_and_single_line__1.xml
+++ b/tests/__snapshots__/FencedCodeRendererTest__it_highlights_code_blocks_with_a_specified_language_and_single_line__1.xml
@@ -5,15 +5,9 @@
     <code class="language-html hljs xml" data-lang="html">
       <span class="loc">
         <span class="hljs-tag">&lt;<span class="hljs-name">generic-form</span></span>
-      </span>
-      <span class="loc">
-        <span class="hljs-tag"><span class="hljs-attr">:showBackButton</span>=<span class="hljs-string">"true"</span></span>
-      </span>
-      <span class="loc">
-        <span class="hljs-tag">    @<span class="hljs-attr">back</span>=<span class="hljs-string">"goBack"</span></span>
-      </span>
-      <span class="loc">
-        <span class="hljs-tag">&gt;</span>
+        <span class="loc"><span class="hljs-attr">:showBackButton</span>=<span class="hljs-string">"true"</span></span>
+        <span class="loc">    @<span class="hljs-attr">back</span>=<span class="hljs-string">"goBack"</span></span>
+        <span class="loc">&gt;</span>
       </span>
       <span class="loc highlighted">
         <span class="hljs-tag">&lt;<span class="hljs-name">input</span> <span class="hljs-attr">type</span>=<span class="hljs-string">"text"</span> <span class="hljs-attr">name</span>=<span class="hljs-string">"send-to"</span>&gt;</span>


### PR DESCRIPTION
It looks like the output of `splitCodeIntoArray()` has changed since 9.18.1.3, which causes the snapshot tests to fail. This appears to have been caused by the fix in https://github.com/scrivo/highlight.php/pull/79. 👍🏻 I've updated the snapshots to cover this.