### PR TITLE
feat: add support for PHP 8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        php: ['7.2', '7.3', '7.4']
+        php: ['7.2', '7.3', '7.4', '8.0']
         dependency-version: [prefer-lowest, prefer-stable]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.os }} - ${{ matrix.dependency-version }}
@@ -39,3 +39,5 @@ jobs:
       run: |
         wget https://scrutinizer-ci.com/ocular.phar
         php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+      # Disable on PHP 8 as Ocular isn't supported
+      if: matrix.php < 8

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         php-version: ${{ matrix.php }}
         tools: composer
-        coverage: none
+        coverage: pcov
 
     - name: Setup Problem Matches
       run: |

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
         }
     ],
     "require": {
-        "php": "^7.2",
-        "league/commonmark": "^1.0",
+        "php": "^7.2|^8.0",
+        "league/commonmark": "^1.5",
         "scrivo/highlight.php": "^9.18.1.4"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "larapack/dd": "^1.0",
-        "phpunit/phpunit": "^8.0",
+        "phpunit/phpunit": "^8.5|^9.4",
         "spatie/phpunit-snapshot-assertions": "^2.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require-dev": {
         "larapack/dd": "^1.0",
         "phpunit/phpunit": "^8.5|^9.4",
-        "spatie/phpunit-snapshot-assertions": "^2.0"
+        "spatie/phpunit-snapshot-assertions": "^2.0|^4.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,16 +14,17 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
+        </include>
+        <report>
+            <html outputDirectory="build/coverage"/>
+            <text outputFile="build/coverage.txt"/>
+            <clover outputFile="build/logs/clover.xml"/>
+        </report>
+    </coverage>
     <logging>
-        <log type="tap" target="build/report.tap"/>
-        <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage"/>
-        <log type="coverage-text" target="build/coverage.txt"/>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
+        <junit outputFile="build/report.junit.xml"/>
     </logging>
 </phpunit>


### PR DESCRIPTION
When using PHPUnit 8.5 (only on PHP 7.2, and `--prefer-lowest`) it will complain about the configuration schema not being valid, which is just because it doesn't support the new `coverage`/`logging` syntax.

This shouldn't matter though as the coverage provided to Ocular is always generated using `--coverage-clover=coverage.clover` so ignores the configuration.