### PR TITLE
Update to Commonmark v2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        php: ['7.2', '7.3', '7.4', '8.0']
+        php: ['7.4', '8.0']
         dependency-version: [prefer-lowest, prefer-stable]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.os }} - ${{ matrix.dependency-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `commonmark-highlighter` will be documented in this file
 
+## 3.0.0 - 2021-08-03
+
+- update to Commonmark v2
+
 ## 2.1.1 - 2020-11-30
 
 - add support for PHP 8

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
         }
     ],
     "require": {
-        "php": "^7.2|^8.0",
-        "league/commonmark": "^1.5",
+        "php": "^7.4|^8.0",
+        "league/commonmark": "^2.0",
         "scrivo/highlight.php": "^9.18.1.4"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^7.4|^8.0",
         "league/commonmark": "^2.0",
-        "scrivo/highlight.php": "^9.18.1.4"
+        "scrivo/highlight.php": "^9.18.1.7"
     },
     "require-dev": {
         "larapack/dd": "^1.0",

--- a/src/FencedCodeRenderer.php
+++ b/src/FencedCodeRenderer.php
@@ -2,19 +2,19 @@
 
 namespace Spatie\CommonMarkHighlighter;
 
-use League\CommonMark\Block\Element\AbstractBlock;
-use League\CommonMark\Block\Element\FencedCode;
-use League\CommonMark\Block\Renderer\BlockRendererInterface;
-use League\CommonMark\Block\Renderer\FencedCodeRenderer as BaseFencedCodeRenderer;
-use League\CommonMark\ElementRendererInterface;
+use League\CommonMark\Extension\CommonMark\Node\Block\FencedCode;
+use League\CommonMark\Extension\CommonMark\Renderer\Block\FencedCodeRenderer as BaseFencedCodeRenderer;
+use League\CommonMark\Node\Node;
+use League\CommonMark\Renderer\ChildNodeRendererInterface;
+use League\CommonMark\Renderer\NodeRendererInterface;
 use League\CommonMark\Util\Xml;
 
-class FencedCodeRenderer implements BlockRendererInterface
+class FencedCodeRenderer implements NodeRendererInterface
 {
     /** @var \Spatie\CommonMarkHighlighter\CodeBlockHighlighter */
     protected $highlighter;
 
-    /** @var \League\CommonMark\Block\Renderer\FencedCodeRenderer */
+    /** @var \League\CommonMark\Extension\CommonMark\Renderer\Block\FencedCodeRenderer */
     protected $baseRenderer;
 
     public function __construct(array $autodetectLanguages = [])
@@ -23,14 +23,14 @@ class FencedCodeRenderer implements BlockRendererInterface
         $this->baseRenderer = new BaseFencedCodeRenderer();
     }
 
-    public function render(AbstractBlock $block, ElementRendererInterface $htmlRenderer, $inTightList = false)
+    public function render(Node $node, ChildNodeRendererInterface $childRenderer)
     {
-        $element = $this->baseRenderer->render($block, $htmlRenderer, $inTightList);
+        $element = $this->baseRenderer->render($node, $childRenderer);
 
         $element->setContents(
             $this->highlighter->highlight(
                 $element->getContents(),
-                $this->getSpecifiedLanguage($block)
+                $this->getSpecifiedLanguage($node)
             )
         );
 

--- a/src/IndentedCodeRenderer.php
+++ b/src/IndentedCodeRenderer.php
@@ -2,17 +2,17 @@
 
 namespace Spatie\CommonMarkHighlighter;
 
-use League\CommonMark\Block\Element\AbstractBlock;
-use League\CommonMark\Block\Renderer\BlockRendererInterface;
-use League\CommonMark\Block\Renderer\IndentedCodeRenderer as BaseIndentedCodeRenderer;
-use League\CommonMark\ElementRendererInterface;
+use League\CommonMark\Extension\CommonMark\Renderer\Block\IndentedCodeRenderer as BaseIndentedCodeRenderer;
+use League\CommonMark\Node\Node;
+use League\CommonMark\Renderer\ChildNodeRendererInterface;
+use League\CommonMark\Renderer\NodeRendererInterface;
 
-class IndentedCodeRenderer implements BlockRendererInterface
+class IndentedCodeRenderer implements NodeRendererInterface
 {
     /** @var \Spatie\CommonMarkHighlighter\CodeBlockHighlighter */
     protected $highlighter;
 
-    /** @var \League\CommonMark\Block\Renderer\IndentedCodeRenderer */
+    /** @var \League\CommonMark\Extension\CommonMark\Renderer\Block\IndentedCodeRenderer */
     protected $baseRenderer;
 
     public function __construct(array $autodetectLanguages = [])
@@ -21,9 +21,9 @@ class IndentedCodeRenderer implements BlockRendererInterface
         $this->baseRenderer = new BaseIndentedCodeRenderer();
     }
 
-    public function render(AbstractBlock $block, ElementRendererInterface $htmlRenderer, $inTightList = false)
+    public function render(Node $node, ChildNodeRendererInterface $childRenderer)
     {
-        $element = $this->baseRenderer->render($block, $htmlRenderer, $inTightList);
+        $element = $this->baseRenderer->render($node, $childRenderer);
 
         $element->setContents(
             $this->highlighter->highlight($element->getContents())

--- a/tests/FencedCodeRendererTest.php
+++ b/tests/FencedCodeRendererTest.php
@@ -2,10 +2,11 @@
 
 namespace Spatie\CommonMarkHighlighter\Tests;
 
-use League\CommonMark\Block\Element\FencedCode;
-use League\CommonMark\DocParser;
-use League\CommonMark\Environment;
-use League\CommonMark\HtmlRenderer;
+use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
+use League\CommonMark\Parser\MarkdownParser;
+use League\CommonMark\Environment\Environment;
+use League\CommonMark\Extension\CommonMark\Node\Block\FencedCode;
+use League\CommonMark\Renderer\HtmlRenderer;
 use PHPUnit\Framework\TestCase;
 use Spatie\CommonMarkHighlighter\FencedCodeRenderer;
 use Spatie\Snapshots\MatchesSnapshots;
@@ -30,15 +31,16 @@ Which looks like this in use:
 Something feels wrong here.
 MARKDOWN;
 
-        $environment = Environment::createCommonMarkEnvironment();
-        $environment->addBlockRenderer(FencedCode::class, new FencedCodeRenderer(['html']));
+        $environment = new Environment();
+        $environment->addExtension(new CommonMarkCoreExtension());
+        $environment->addRenderer(FencedCode::class, new FencedCodeRenderer(['html']));
 
-        $parser = new DocParser($environment);
+        $parser = new MarkdownParser($environment);
         $htmlRenderer = new HtmlRenderer($environment);
 
         $document = $parser->parse($markdown);
 
-        $html = $htmlRenderer->renderBlock($document);
+        $html = $htmlRenderer->renderDocument($document);
 
         $this->assertMatchesXmlSnapshot('<div>'.$html.'</div>');
     }
@@ -62,15 +64,16 @@ Which looks like this in use:
 Something feels wrong here.
 MARKDOWN;
 
-        $environment = Environment::createCommonMarkEnvironment();
-        $environment->addBlockRenderer(FencedCode::class, new FencedCodeRenderer(['html']));
+        $environment = new Environment();
+        $environment->addExtension(new CommonMarkCoreExtension());
+        $environment->addRenderer(FencedCode::class, new FencedCodeRenderer(['html']));
 
-        $parser = new DocParser($environment);
+        $parser = new MarkdownParser($environment);
         $htmlRenderer = new HtmlRenderer($environment);
 
         $document = $parser->parse($markdown);
 
-        $html = $htmlRenderer->renderBlock($document);
+        $html = $htmlRenderer->renderDocument($document);
 
         $this->assertMatchesXmlSnapshot('<div>'.$html.'</div>');
     }
@@ -94,15 +97,16 @@ Which looks like this in use:
 Something feels wrong here.
 MARKDOWN;
 
-        $environment = Environment::createCommonMarkEnvironment();
-        $environment->addBlockRenderer(FencedCode::class, new FencedCodeRenderer(['html']));
+        $environment = new Environment();
+        $environment->addExtension(new CommonMarkCoreExtension());
+        $environment->addRenderer(FencedCode::class, new FencedCodeRenderer(['html']));
 
-        $parser = new DocParser($environment);
+        $parser = new MarkdownParser($environment);
         $htmlRenderer = new HtmlRenderer($environment);
 
         $document = $parser->parse($markdown);
 
-        $html = $htmlRenderer->renderBlock($document);
+        $html = $htmlRenderer->renderDocument($document);
 
         $this->assertMatchesXmlSnapshot('<div>'.$html.'</div>');
     }
@@ -126,15 +130,16 @@ Which looks like this in use:
 Something feels wrong here.
 MARKDOWN;
 
-        $environment = Environment::createCommonMarkEnvironment();
-        $environment->addBlockRenderer(FencedCode::class, new FencedCodeRenderer(['html']));
+        $environment = new Environment();
+        $environment->addExtension(new CommonMarkCoreExtension());
+        $environment->addRenderer(FencedCode::class, new FencedCodeRenderer(['html']));
 
-        $parser = new DocParser($environment);
+        $parser = new MarkdownParser($environment);
         $htmlRenderer = new HtmlRenderer($environment);
 
         $document = $parser->parse($markdown);
 
-        $html = $htmlRenderer->renderBlock($document);
+        $html = $htmlRenderer->renderDocument($document);
 
         $this->assertMatchesXmlSnapshot('<div>'.$html.'</div>');
     }
@@ -158,15 +163,16 @@ Which looks like this in use:
 Something feels wrong here.
 MARKDOWN;
 
-        $environment = Environment::createCommonMarkEnvironment();
-        $environment->addBlockRenderer(FencedCode::class, new FencedCodeRenderer(['html']));
+        $environment = new Environment();
+        $environment->addExtension(new CommonMarkCoreExtension());
+        $environment->addRenderer(FencedCode::class, new FencedCodeRenderer(['html']));
 
-        $parser = new DocParser($environment);
+        $parser = new MarkdownParser($environment);
         $htmlRenderer = new HtmlRenderer($environment);
 
         $document = $parser->parse($markdown);
 
-        $html = $htmlRenderer->renderBlock($document);
+        $html = $htmlRenderer->renderDocument($document);
 
         $this->assertMatchesXmlSnapshot('<div>'.$html.'</div>');
     }
@@ -190,15 +196,16 @@ Which looks like this in use:
 Something feels wrong here.
 MARKDOWN;
 
-        $environment = Environment::createCommonMarkEnvironment();
-        $environment->addBlockRenderer(FencedCode::class, new FencedCodeRenderer(['html']));
+        $environment = new Environment();
+        $environment->addExtension(new CommonMarkCoreExtension());
+        $environment->addRenderer(FencedCode::class, new FencedCodeRenderer(['html']));
 
-        $parser = new DocParser($environment);
+        $parser = new MarkdownParser($environment);
         $htmlRenderer = new HtmlRenderer($environment);
 
         $document = $parser->parse($markdown);
 
-        $html = $htmlRenderer->renderBlock($document);
+        $html = $htmlRenderer->renderDocument($document);
 
         $this->assertMatchesXmlSnapshot('<div>'.$html.'</div>');
     }
@@ -222,15 +229,16 @@ Which looks like this in use:
 Something feels wrong here.
 MARKDOWN;
 
-        $environment = Environment::createCommonMarkEnvironment();
-        $environment->addBlockRenderer(FencedCode::class, new FencedCodeRenderer(['html']));
+        $environment = new Environment();
+        $environment->addExtension(new CommonMarkCoreExtension());
+        $environment->addRenderer(FencedCode::class, new FencedCodeRenderer(['html']));
 
-        $parser = new DocParser($environment);
+        $parser = new MarkdownParser($environment);
         $htmlRenderer = new HtmlRenderer($environment);
 
         $document = $parser->parse($markdown);
 
-        $html = $htmlRenderer->renderBlock($document);
+        $html = $htmlRenderer->renderDocument($document);
 
         $this->assertMatchesXmlSnapshot('<div>'.$html.'</div>');
     }
@@ -249,15 +257,16 @@ $isUserPending = $user->isStatus("pending");
 Something feels wrong here.
 MARKDOWN;
 
-        $environment = Environment::createCommonMarkEnvironment();
-        $environment->addBlockRenderer(FencedCode::class, new FencedCodeRenderer(['html']));
+        $environment = new Environment();
+        $environment->addExtension(new CommonMarkCoreExtension());
+        $environment->addRenderer(FencedCode::class, new FencedCodeRenderer(['html']));
 
-        $parser = new DocParser($environment);
+        $parser = new MarkdownParser($environment);
         $htmlRenderer = new HtmlRenderer($environment);
 
         $document = $parser->parse($markdown);
 
-        $html = $htmlRenderer->renderBlock($document);
+        $html = $htmlRenderer->renderDocument($document);
 
         $this->assertMatchesXmlSnapshot('<div>'.$html.'</div>');
     }
@@ -278,15 +287,16 @@ Which looks like this in use:
 Something feels wrong here.
 MARKDOWN;
 
-        $environment = Environment::createCommonMarkEnvironment();
-        $environment->addBlockRenderer(FencedCode::class, new FencedCodeRenderer(['html']));
+        $environment = new Environment();
+        $environment->addExtension(new CommonMarkCoreExtension());
+        $environment->addRenderer(FencedCode::class, new FencedCodeRenderer(['html']));
 
-        $parser = new DocParser($environment);
+        $parser = new MarkdownParser($environment);
         $htmlRenderer = new HtmlRenderer($environment);
 
         $document = $parser->parse($markdown);
 
-        $html = $htmlRenderer->renderBlock($document);
+        $html = $htmlRenderer->renderDocument($document);
 
         $this->assertMatchesXmlSnapshot('<div>'.$html.'</div>');
     }

--- a/tests/FencedCodeRendererTest.php
+++ b/tests/FencedCodeRendererTest.php
@@ -2,10 +2,10 @@
 
 namespace Spatie\CommonMarkHighlighter\Tests;
 
-use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
-use League\CommonMark\Parser\MarkdownParser;
 use League\CommonMark\Environment\Environment;
+use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
 use League\CommonMark\Extension\CommonMark\Node\Block\FencedCode;
+use League\CommonMark\Parser\MarkdownParser;
 use League\CommonMark\Renderer\HtmlRenderer;
 use PHPUnit\Framework\TestCase;
 use Spatie\CommonMarkHighlighter\FencedCodeRenderer;

--- a/tests/IndentedCodeRendererTest.php
+++ b/tests/IndentedCodeRendererTest.php
@@ -2,10 +2,11 @@
 
 namespace Spatie\CommonMarkHighlighter\Tests;
 
-use League\CommonMark\Block\Element\IndentedCode;
-use League\CommonMark\DocParser;
-use League\CommonMark\Environment;
-use League\CommonMark\HtmlRenderer;
+use League\CommonMark\Environment\Environment;
+use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
+use League\CommonMark\Extension\CommonMark\Node\Block\IndentedCode;
+use League\CommonMark\Parser\MarkdownParser;
+use League\CommonMark\Renderer\HtmlRenderer;
 use PHPUnit\Framework\TestCase;
 use Spatie\CommonMarkHighlighter\IndentedCodeRenderer;
 use Spatie\Snapshots\MatchesSnapshots;
@@ -28,15 +29,16 @@ Which looks like this in use:
 Something feels wrong here.
 MARKDOWN;
 
-        $environment = Environment::createCommonMarkEnvironment();
-        $environment->addBlockRenderer(IndentedCode::class, new IndentedCodeRenderer(['html']));
+        $environment = new Environment();
+        $environment->addExtension(new CommonMarkCoreExtension());
+        $environment->addRenderer(IndentedCode::class, new IndentedCodeRenderer(['html']));
 
-        $parser = new DocParser($environment);
+        $parser = new MarkdownParser($environment);
         $htmlRenderer = new HtmlRenderer($environment);
 
         $document = $parser->parse($markdown);
 
-        $html = $htmlRenderer->renderBlock($document);
+        $html = $htmlRenderer->renderDocument($document);
 
         $this->assertMatchesXmlSnapshot('<div>'.$html.'</div>');
     }

--- a/tests/__snapshots__/FencedCodeRendererTest__it_highlights_code_blocks_with_a_specified_language_and_line_range__1.xml
+++ b/tests/__snapshots__/FencedCodeRendererTest__it_highlights_code_blocks_with_a_specified_language_and_line_range__1.xml
@@ -5,9 +5,15 @@
     <code class="language-html hljs xml" data-lang="html">
       <span class="loc">
         <span class="hljs-tag">&lt;<span class="hljs-name">generic-form</span></span>
-        <span class="loc highlighted"><span class="hljs-attr">:showBackButton</span>=<span class="hljs-string">"true"</span></span>
-        <span class="loc highlighted">    @<span class="hljs-attr">back</span>=<span class="hljs-string">"goBack"</span></span>
-        <span class="loc">&gt;</span>
+      </span>
+      <span class="loc highlighted">
+        <span class="hljs-tag"><span class="hljs-attr">:showBackButton</span>=<span class="hljs-string">"true"</span></span>
+      </span>
+      <span class="loc highlighted">
+        <span class="hljs-tag">    @<span class="hljs-attr">back</span>=<span class="hljs-string">"goBack"</span></span>
+      </span>
+      <span class="loc">
+        <span class="hljs-tag">&gt;</span>
       </span>
       <span class="loc">
         <span class="hljs-tag">&lt;<span class="hljs-name">input</span> <span class="hljs-attr">type</span>=<span class="hljs-string">"text"</span> <span class="hljs-attr">name</span>=<span class="hljs-string">"send-to"</span>&gt;</span>

--- a/tests/__snapshots__/FencedCodeRendererTest__it_highlights_code_blocks_with_a_specified_language_and_lines_out_of_order__1.xml
+++ b/tests/__snapshots__/FencedCodeRendererTest__it_highlights_code_blocks_with_a_specified_language_and_lines_out_of_order__1.xml
@@ -5,9 +5,15 @@
     <code class="language-html hljs xml" data-lang="html">
       <span class="loc highlighted">
         <span class="hljs-tag">&lt;<span class="hljs-name">generic-form</span></span>
-        <span class="loc highlighted"><span class="hljs-attr">:showBackButton</span>=<span class="hljs-string">"true"</span></span>
-        <span class="loc highlighted">    @<span class="hljs-attr">back</span>=<span class="hljs-string">"goBack"</span></span>
-        <span class="loc">&gt;</span>
+      </span>
+      <span class="loc highlighted">
+        <span class="hljs-tag"><span class="hljs-attr">:showBackButton</span>=<span class="hljs-string">"true"</span></span>
+      </span>
+      <span class="loc highlighted">
+        <span class="hljs-tag">    @<span class="hljs-attr">back</span>=<span class="hljs-string">"goBack"</span></span>
+      </span>
+      <span class="loc">
+        <span class="hljs-tag">&gt;</span>
       </span>
       <span class="loc">
         <span class="hljs-tag">&lt;<span class="hljs-name">input</span> <span class="hljs-attr">type</span>=<span class="hljs-string">"text"</span> <span class="hljs-attr">name</span>=<span class="hljs-string">"send-to"</span>&gt;</span>

--- a/tests/__snapshots__/FencedCodeRendererTest__it_highlights_code_blocks_with_a_specified_language_and_mix_ranges_specific_lines__1.xml
+++ b/tests/__snapshots__/FencedCodeRendererTest__it_highlights_code_blocks_with_a_specified_language_and_mix_ranges_specific_lines__1.xml
@@ -5,9 +5,15 @@
     <code class="language-html hljs xml" data-lang="html">
       <span class="loc highlighted">
         <span class="hljs-tag">&lt;<span class="hljs-name">generic-form</span></span>
-        <span class="loc highlighted"><span class="hljs-attr">:showBackButton</span>=<span class="hljs-string">"true"</span></span>
-        <span class="loc highlighted">    @<span class="hljs-attr">back</span>=<span class="hljs-string">"goBack"</span></span>
-        <span class="loc">&gt;</span>
+      </span>
+      <span class="loc highlighted">
+        <span class="hljs-tag"><span class="hljs-attr">:showBackButton</span>=<span class="hljs-string">"true"</span></span>
+      </span>
+      <span class="loc highlighted">
+        <span class="hljs-tag">    @<span class="hljs-attr">back</span>=<span class="hljs-string">"goBack"</span></span>
+      </span>
+      <span class="loc">
+        <span class="hljs-tag">&gt;</span>
       </span>
       <span class="loc highlighted">
         <span class="hljs-tag">&lt;<span class="hljs-name">input</span> <span class="hljs-attr">type</span>=<span class="hljs-string">"text"</span> <span class="hljs-attr">name</span>=<span class="hljs-string">"send-to"</span>&gt;</span>

--- a/tests/__snapshots__/FencedCodeRendererTest__it_highlights_code_blocks_with_a_specified_language_and_multiple_line_range__1.xml
+++ b/tests/__snapshots__/FencedCodeRendererTest__it_highlights_code_blocks_with_a_specified_language_and_multiple_line_range__1.xml
@@ -5,9 +5,15 @@
     <code class="language-html hljs xml" data-lang="html">
       <span class="loc">
         <span class="hljs-tag">&lt;<span class="hljs-name">generic-form</span></span>
-        <span class="loc highlighted"><span class="hljs-attr">:showBackButton</span>=<span class="hljs-string">"true"</span></span>
-        <span class="loc highlighted">    @<span class="hljs-attr">back</span>=<span class="hljs-string">"goBack"</span></span>
-        <span class="loc">&gt;</span>
+      </span>
+      <span class="loc highlighted">
+        <span class="hljs-tag"><span class="hljs-attr">:showBackButton</span>=<span class="hljs-string">"true"</span></span>
+      </span>
+      <span class="loc highlighted">
+        <span class="hljs-tag">    @<span class="hljs-attr">back</span>=<span class="hljs-string">"goBack"</span></span>
+      </span>
+      <span class="loc">
+        <span class="hljs-tag">&gt;</span>
       </span>
       <span class="loc highlighted">
         <span class="hljs-tag">&lt;<span class="hljs-name">input</span> <span class="hljs-attr">type</span>=<span class="hljs-string">"text"</span> <span class="hljs-attr">name</span>=<span class="hljs-string">"send-to"</span>&gt;</span>

--- a/tests/__snapshots__/FencedCodeRendererTest__it_highlights_code_blocks_with_a_specified_language_and_multiple_separate_lines__1.xml
+++ b/tests/__snapshots__/FencedCodeRendererTest__it_highlights_code_blocks_with_a_specified_language_and_multiple_separate_lines__1.xml
@@ -5,9 +5,15 @@
     <code class="language-html hljs xml" data-lang="html">
       <span class="loc highlighted">
         <span class="hljs-tag">&lt;<span class="hljs-name">generic-form</span></span>
-        <span class="loc"><span class="hljs-attr">:showBackButton</span>=<span class="hljs-string">"true"</span></span>
-        <span class="loc">    @<span class="hljs-attr">back</span>=<span class="hljs-string">"goBack"</span></span>
-        <span class="loc">&gt;</span>
+      </span>
+      <span class="loc">
+        <span class="hljs-tag"><span class="hljs-attr">:showBackButton</span>=<span class="hljs-string">"true"</span></span>
+      </span>
+      <span class="loc">
+        <span class="hljs-tag">    @<span class="hljs-attr">back</span>=<span class="hljs-string">"goBack"</span></span>
+      </span>
+      <span class="loc">
+        <span class="hljs-tag">&gt;</span>
       </span>
       <span class="loc">
         <span class="hljs-tag">&lt;<span class="hljs-name">input</span> <span class="hljs-attr">type</span>=<span class="hljs-string">"text"</span> <span class="hljs-attr">name</span>=<span class="hljs-string">"send-to"</span>&gt;</span>

--- a/tests/__snapshots__/FencedCodeRendererTest__it_highlights_code_blocks_with_a_specified_language_and_single_line__1.xml
+++ b/tests/__snapshots__/FencedCodeRendererTest__it_highlights_code_blocks_with_a_specified_language_and_single_line__1.xml
@@ -5,9 +5,15 @@
     <code class="language-html hljs xml" data-lang="html">
       <span class="loc">
         <span class="hljs-tag">&lt;<span class="hljs-name">generic-form</span></span>
-        <span class="loc"><span class="hljs-attr">:showBackButton</span>=<span class="hljs-string">"true"</span></span>
-        <span class="loc">    @<span class="hljs-attr">back</span>=<span class="hljs-string">"goBack"</span></span>
-        <span class="loc">&gt;</span>
+      </span>
+      <span class="loc">
+        <span class="hljs-tag"><span class="hljs-attr">:showBackButton</span>=<span class="hljs-string">"true"</span></span>
+      </span>
+      <span class="loc">
+        <span class="hljs-tag">    @<span class="hljs-attr">back</span>=<span class="hljs-string">"goBack"</span></span>
+      </span>
+      <span class="loc">
+        <span class="hljs-tag">&gt;</span>
       </span>
       <span class="loc highlighted">
         <span class="hljs-tag">&lt;<span class="hljs-name">input</span> <span class="hljs-attr">type</span>=<span class="hljs-string">"text"</span> <span class="hljs-attr">name</span>=<span class="hljs-string">"send-to"</span>&gt;</span>


### PR DESCRIPTION
# Description
This pull request makes commonmark-highlighter compatible with league/commonmark v2. By upgrading to v2, support for v1 is dropped. **This is a breaking change**, and therefor I marked the release in the changelog as 3.0.


## Changes: 
- Removed php 7.2 and php 7.3 from the Github Actions tests because commonmark now requires at least php 7.4 (see: https://commonmark.thephpleague.com/2.0/upgrading/integrators/#minimum-php-version)
- Added a changelog entry in the style of the previous commonmark upgrade. This is now a new major version.
- Updated composer.json to be in line with the new commonmark requirements
- Updated the tests

## Changes to tests:
highlight.php produces different output depending on the installed version: 
- Without my changes to the fixtures of the tests: If you run the tests with highlight.php locked at exactly 9.18.1.4 all the tests pass.
- Using the latest version (9.18.1.7) the generated output differs which causes the tests to fail.
**I updated the tests to use the newly generated output.** However, now testing for "prefer-lowest" fails because .4 is installed instead of .7. 

I am looking forward to suggestions on how I can fix this tricky situation (fixtures). 

TLDR on tests: highlight.php 9.18.1.4 generates different output than 9.18.1.7. I updated the fixtures to work with the latest version. Tests fail because of prefer-lowest.

## Closing

Let me know if there is anything else you need.
